### PR TITLE
use Moo instead of Any::Moose

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,7 +2,8 @@ use inc::Module::Install;
 name 'Web-oEmbed';
 all_from 'lib/Web/oEmbed.pm';
 
-requires 'Any::Moose';
+requires 'Moo';
+requires 'Type::Tiny';
 requires 'LWP';
 requires 'XML::LibXML::Simple';
 requires 'JSON::XS';

--- a/lib/Web/oEmbed.pm
+++ b/lib/Web/oEmbed.pm
@@ -4,11 +4,16 @@ use strict;
 use 5.8.1;
 our $VERSION = '0.04';
 
-use Any::Moose;
+use Moo;
+use Types::Standard qw(ArrayRef);
+use Type::Utils qw(class_type);
+
+my $LWPUserAgent = class_type({ class => "LWP::UserAgent" });
+
 has 'format'    => (is => 'rw', default => 'json');
 has 'discovery' => (is => 'rw');
-has 'providers' => (is => 'rw', isa => 'ArrayRef', default => sub { [] });
-has 'agent'     => (is => 'rw', isa => 'LWP::UserAgent', default => sub {
+has 'providers' => (is => 'rw', isa => ArrayRef, default => sub { [] }, coerce => 1);
+has 'agent'     => (is => 'rw', isa => $LWPUserAgent, default => sub {
                         require LWP::UserAgent;
                         LWP::UserAgent->new( agent => __PACKAGE__ . "/" . $VERSION );
                     });

--- a/lib/Web/oEmbed/Response.pm
+++ b/lib/Web/oEmbed/Response.pm
@@ -1,9 +1,12 @@
 package Web::oEmbed::Response;
 use strict;
 use Carp;
-use Any::Moose;
+use Moo;
+use Type::Utils qw(class_type);
 
-has 'http_response', is => 'ro', isa => 'HTTP::Response';
+my $HTTPResponse = class_type({ class => "HTTP::Response" });
+
+has 'http_response', is => 'ro', isa => $HTTPResponse, coerce => 1;
 
 has 'matched_uri', is => 'ro';
 has 'type', is => 'rw';


### PR DESCRIPTION
This module uses Any::Moose. But, Any::Moose has been [deprecated on version 0.19](https://metacpan.org/pod/release/SARTAK/Any-Moose-0.19/lib/Any/Moose.pm).

So, I implemented using Moo instead of Any::Moose.